### PR TITLE
Removes Unused Dependencies and Simplifies Arg Processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,7 @@ let supposed = null
 // resolve the dependency graph
 function Supposed (options) {
   const { allSettled } = allSettledFactory({})
-  const { readEnvvars } = readEnvvarsFactory({
-    isValidUnit: time.isValidUnit,
-    isValidReportOrder: (value) => {
-      return value === REPORT_ORDERS.NON_DETERMINISTIC || value === REPORT_ORDERS.DETERMINISTIC
-    }
-  })
+  const { readEnvvars } = readEnvvarsFactory({})
 
   const envvars = {
     ...{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supposed",
-  "version": "1.0.5-beta.1",
+  "version": "1.0.6-beta.1",
   "description": "a test library for node.js",
   "main": "index.js",
   "scripts": {

--- a/src/read-envvars.js
+++ b/src/read-envvars.js
@@ -1,20 +1,20 @@
 module.exports = {
   name: 'readEnvvars',
-  factory: (dependencies) => {
+  factory: () => {
     'use strict'
 
     function Switch (lowercaseLetter) { // eslint-disable-line no-unused-vars
       return { switch: `-${lowercaseLetter}`.toUpperCase() }
     }
 
-    function Swatch (name) { // eslint-disable-line no-unused-vars
-      return { swatch: `--${name}`.toUpperCase() }
+    function Swatch (name) {
+      return { switch: `--${name}`.toUpperCase() }
     }
 
     function Option (lowercaseLetter, name) {
       return {
-        switch: `-${lowercaseLetter}`.toUpperCase(),
-        option: `--${name}`.toUpperCase()
+        switch: Switch(lowercaseLetter).switch,
+        option: Swatch(name).switch
       }
     }
 
@@ -30,16 +30,17 @@ module.exports = {
         )
       ) {
         return args[idx + 1]
-      } else if (target.swatch === _argValue) {
-        return true
-      } else if (target.switch === _argValue) {
+      } else if (
+        target.switch === _argValue ||
+        target.option === _argValue
+      ) {
         return true
       }
 
       return false
     }
 
-    const readEnvvars = () => {
+    const _readEnvvars = () => {
       const output = {
         reporters: process.env.SUPPOSED_REPORTERS
           ? process.env.SUPPOSED_REPORTERS.split(',').map((reporter) => reporter.trim().toUpperCase())
@@ -66,13 +67,11 @@ module.exports = {
           : undefined
       }
 
-      if (process.env.SUPPOSED_TIME_UNITS && !output.timeUnits) {
-        console.log(`${process.env.SUPPOSED_TIME_UNITS} is not a supported time unit`)
-      }
+      return output
+    }
 
-      if (process.env.SUPPOSED_REPORT_ORDER && !output.reportOrder) {
-        console.log(`${process.env.SUPPOSED_REPORT_ORDER} is not a supported report order`)
-      }
+    const _readArgs = () => {
+      const output = {}
 
       if (!Array.isArray(process.argv)) {
         return output
@@ -117,6 +116,10 @@ module.exports = {
       }) // /forEach
 
       return output
+    }
+
+    const readEnvvars = () => {
+      return { ..._readEnvvars(), ..._readArgs() }
     } // /readEnvvars
 
     return { readEnvvars }


### PR DESCRIPTION
At one point I performed validation while reading envvars. As I made
changes so the envvars could be established programmatically, that
validation moved. This removes the artifacts from the previous way that
I validated args and envvars.

Also simplifies arg processing. There was an unnecessary condition in 
`findMatch` that was also an artifact of a previous way that I read 
arguments. This condition is removed by aligning the property names 
of `Switch` and `Swatch`. 