### PR TITLE
feat: adds support for es modules

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 overrides:
   shelljs@<0.8.5: '>=0.8.5'
@@ -28,7 +28,7 @@ devDependencies:
   '@types/node': 17.0.23
   chai: 4.3.6
   eslint: 8.10.0
-  eslint-config-standard: 16.0.3_8f50d7c1b6c57306b9c9430e4ac9cf2e
+  eslint-config-standard: 16.0.3_r5inpqnwyvzqnoojimhevsopfy
   eslint-plugin-import: 2.25.4_eslint@8.10.0
   eslint-plugin-node: 11.1.0_eslint@8.10.0
   eslint-plugin-promise: 6.0.0_eslint@8.10.0
@@ -328,6 +328,8 @@ packages:
     resolution: {integrity: sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.9:
@@ -1583,12 +1585,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -1733,7 +1745,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-standard/16.0.3_8f50d7c1b6c57306b9c9430e4ac9cf2e:
+  /eslint-config-standard/16.0.3_r5inpqnwyvzqnoojimhevsopfy:
     resolution: {integrity: sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==}
     peerDependencies:
       eslint: ^7.12.1
@@ -1752,14 +1764,33 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_ulu2225r2ychl26a37c6o2rfje:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-es/3.0.1_eslint@8.10.0:
@@ -1777,7 +1808,11 @@ packages:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
@@ -1785,7 +1820,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.10.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_ulu2225r2ychl26a37c6o2rfje
       has: 1.0.3
       is-core-module: 2.8.1
       is-glob: 4.0.3
@@ -1793,6 +1828,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-node/11.1.0_eslint@8.10.0:

--- a/src/runners/find-files.js
+++ b/src/runners/find-files.js
@@ -13,7 +13,7 @@ module.exports = {
       const self = {
         cwd: process.cwd(),
         directories: ['.'],
-        matchesNamingConvention: /.([-.]test(s?)\.js)|([-.]spec(s?)\.js)$/i,
+        matchesNamingConvention: /.([-.]test(s?)\.(js|cjs|mjs))|([-.]spec(s?)\.(js|cjs|mjs))$/i,
         matchesIgnoredConvention: /node_modules/i,
         injectSuite: true
       }

--- a/src/runners/resolve-tests.js
+++ b/src/runners/resolve-tests.js
@@ -3,25 +3,27 @@ module.exports = {
   factory: () => {
     'use strict'
 
-    const resolveTests = () => (context) => {
+    const resolveTests = () => async (context) => {
       const { paths } = context
 
       if (!paths) {
         throw new Error('resolve-tests expects paths to the tests to be provided')
       }
 
+      const tests = []
+
+      for (const path of paths) {
+        try {
+          tests.push({ path, test: await import(path) })
+        } catch (e) {
+          e.filePath = path
+          tests.push({ path, err: e })
+        }
+      }
+
       return {
         ...context,
-        ...{
-          tests: paths.map((path) => {
-            try {
-              return { path, test: require(path) }
-            } catch (e) {
-              e.filePath = path
-              return { path, err: e }
-            }
-          })
-        }
+        ...{ tests }
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ const suite = supposed.Suite({
 // })
 
 module.exports = suite.runner({
-  cwd: path.join(__dirname, 'tests.node'),
+  directories: ['./tests.node', './tests.es'],
   matchesIgnoredConvention: /discoverer-meta-specs|node_modules/i
 })
   // .plan()

--- a/tests.es/divide-by-0.mjs
+++ b/tests.es/divide-by-0.mjs
@@ -1,0 +1,3 @@
+import divideBy from './divide-by.mjs'
+
+export default divideBy(0)

--- a/tests.es/divide-by.mjs
+++ b/tests.es/divide-by.mjs
@@ -1,0 +1,2 @@
+export default (numToDivideBy) =>
+  (numToDivide) => numToDivide / numToDivideBy

--- a/tests.es/suite-specs.mjs
+++ b/tests.es/suite-specs.mjs
@@ -1,0 +1,13 @@
+import divideBy0 from './divide-by-0.mjs'
+
+export default function (test) {
+  return test('es modules', {
+    'when the spec and modules are es modules': {
+      when: divideBy0(42),
+      'it should work with imports and exports': (t, err, actual) => {
+        t.ifError(err)
+        t.strictEqual(actual, Infinity)
+      }
+    }
+  })
+}


### PR DESCRIPTION
I used require to load modules in the runner, but that only has support for commonJS modules. There is a dynamic import global that is functional like require, but is asynchronous and works with both commonJS and ES modules. This adds tests to verify that the change to using that works. It also introduces mjs and cjs to the glob match for test files.