### PR TITLE
feat: adds supposed command to the package

### DIFF
--- a/bin/supposed.js
+++ b/bin/supposed.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const supposed = require('supposed')
+
+supposed.Suite().runner().run()
+  .then((results) => {
+    if (results.totals.failed > 0) {
+      process.exit(results.totals.failed)
+    }
+  }).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.log(err)
+    process.exit(1)
+  })

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "description": "a test library for node.js",
   "main": "index.js",
+  "bin": {
+    "supposed": "./bin/supposed.js"
+  },
   "scripts": {
     "build": "node build.browser.js",
     "lint": "eslint .",

--- a/test-browser.js
+++ b/test-browser.js
@@ -1,4 +1,5 @@
 const suite = require('./tests.browser/server.js')
+
 module.exports = suite.then((context) => {
   context.server.close()
 


### PR DESCRIPTION
Adds a simple, unconfigured runner to the package so you can `npx supposed` to run tests against your working directory. Some configuration options, such as the directory and working directory aren't exposed yet, but it's better than nothing.