### PR TITLE
chore: adds docs to README for bin runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
       run: pnpm run test:coverage:ci
 
     - name: Commit Browser Build
+      continue-on-error: true # this will fail if there were no changes to the dist
       run: |
         git add -A
         git commit -m "cicd: updates browser distribution"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ supposed.Suite({
 }).run()
 ```
 
+## The built in runner
+If you are writing traditional tests and:
+
+-   aren't injecting anything
+-   don't need special configurations for cwd, directories, etc.
+
+Then you can use the built in runner to find and execute the tests in your project:
+
+```
+npx supposed -r nyan
+```
+
+Or add it to your package.json:
+
+```
+"scripts": {
+    "test": "supposed -r nyan"
+}
+```
+
 ## Test Syntax and Domain Service Languages (DSLs)
 
 ### The BDD DSL (Given, When, Then)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1242,8 +1242,8 @@ packages:
     resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
     dev: true
 
-  /@types/yauzl/2.9.2:
-    resolution: {integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==}
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
       '@types/node': 17.0.23
@@ -1424,7 +1424,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001325
+      caniuse-lite: 1.0.30001458
       electron-to-chromium: 1.4.106
       escalade: 3.1.1
       node-releases: 2.0.2
@@ -1469,8 +1469,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /caniuse-lite/1.0.30001325:
-    resolution: {integrity: sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==}
+  /caniuse-lite/1.0.30001458:
+    resolution: {integrity: sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==}
     dev: true
 
   /chai/4.3.6:
@@ -1994,7 +1994,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.9.2
+      '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Also updates the publish action to ignore failures to commit the browser distribution. That fails when there is nothing to commit, so this ignores failures in that step.