### PR TITLE
fix: fixes per test results with the bin runner

### DIFF
--- a/bin/supposed.js
+++ b/bin/supposed.js
@@ -2,7 +2,7 @@
 
 const supposed = require('supposed')
 
-supposed.Suite().runner().run()
+supposed.Suite({ reporter: 'noop' }).runner().run()
   .then((results) => {
     if (results.totals.failed > 0) {
       process.exit(results.totals.failed)


### PR DESCRIPTION
The bin runner didn't have the noop reporter configured so both the suite results and the per-test results were being rendered to the console. This sets the noop reporter as the per-test reporter so only suite results are rendered to the console.